### PR TITLE
履歴をサーバー・DMごとに持つように変更

### DIFF
--- a/ai_risajuu.py
+++ b/ai_risajuu.py
@@ -25,10 +25,6 @@ class Reply(BaseModel):
     body: str
 
 
-def split_message_text(text, chunk_size=1500):
-    return [text[i : i + chunk_size] for i in range(0, len(text), chunk_size)]
-
-
 class AI_risajuu:
     def __init__(self, api_key, common_instruction, system_instruction):
         self.main_model_name = os.getenv("MAIN_MODEL_NAME")

--- a/ai_risajuu.py
+++ b/ai_risajuu.py
@@ -1,5 +1,4 @@
 import os
-import random
 from enum import Enum
 
 from google import genai
@@ -50,27 +49,22 @@ class AI_risajuu:
         history = History(contents=self.chat.get_history())
         return history.model_dump_json(indent=2)
 
-    async def react(self, input_text, probability):
-        if random.random() < probability:
-            emoji = self.client.models.generate_content(
-                model=self.sub_model_name,
-                contents=[
-                    """
-                        # 指示
-                        「"""
-                    + input_text
-                    + """」というメッセージへのリアクションとして適切な絵文字を一つだけ選んでください。
-                    # 注意
-                    出力には**絵文字一文字のみ**を取ってください。余計なテキストや説明は**絶対に**含めず、**絵文字一文字のみ**を出力してください。
-                    """
-                ],
-                config=GenerateContentConfig(
-                    safety_settings=get_safety_settings(),
-                ),
-            )
-            return emoji.text.strip()
-        else:
-            return None
+    async def react(self, input_text):
+        emoji = await self.client.aio.models.generate_content(
+            model=self.sub_model_name,
+            contents=[
+                """
+                    # 指示
+                    「"""
+                + input_text
+                + """」というメッセージへのリアクションとして適切な絵文字を一つだけ選んでください。
+                # 注意
+                出力には**絵文字一文字のみ**を取ってください。余計なテキストや説明は**絶対に**含めず、**絵文字一文字のみ**を出力してください。
+                """
+            ],
+            config=GenerateContentConfig(safety_settings=get_safety_settings()),
+        )
+        return emoji.text.strip()
 
     async def reply(self, input_text, attachments=[]):
         if input_text.startswith("あ、これはりさじゅう反応しないでね"):
@@ -92,12 +86,11 @@ class AI_risajuu:
                     )
                 )
                 os.remove(attachment.filename)
-                
+
             parts = [text]
             parts.extend(files)
             config = GenerateContentConfig(
                 system_instruction=self.common_instruction + self.current_system_instruction,
-
                 tools=[self.google_search_tool, self.url_context_tool],
                 safety_settings=get_safety_settings(),
             )

--- a/discord_client.py
+++ b/discord_client.py
@@ -3,10 +3,25 @@ import datetime
 import os
 import random
 import tempfile
+from enum import Enum
 
 import discord
+from pydantic import BaseModel
 
-from ai_risajuu import ReplyType
+from ai_risajuu import AI_risajuu, ReplyType
+
+
+class InstanceType(str, Enum):
+    server = "server"
+    dm = "dm"
+
+
+class InstanceID(BaseModel):
+    type: InstanceType
+    id: int
+
+    class Config:
+        frozen = True
 
 
 def split_message_text(text, chunk_size=1500):
@@ -14,11 +29,17 @@ def split_message_text(text, chunk_size=1500):
 
 
 class Risajuu_discord_client(discord.Client):
-    def __init__(self, risajuu):
+    def __init__(self, risajuu_config):
         intents = discord.Intents.default()
         intents.message_content = True
         super().__init__(intents=intents)
-        self.risajuu = risajuu
+
+        self.risajuu_config = risajuu_config
+        self.risajuu_instance = {}
+        self.targets = []
+        for target in os.getenv("TARGET_CHANNEL_NAME").split(","):
+            t = target.split("/")
+            self.targets.append((t[0], t[1]))
 
     async def on_ready(self):
         print(f"We have logged in as {self.user}")
@@ -27,29 +48,42 @@ class Risajuu_discord_client(discord.Client):
         if message.author.bot:
             return
 
+        is_DM = message.channel.type == discord.ChannelType.private
+
+        if is_DM:
+            risajuu_id = InstanceID(type=InstanceType.dm, id=message.channel.id)
+        else:
+            risajuu_id = InstanceID(type=InstanceType.server, id=message.guild.id)
+
+        if risajuu_id in self.risajuu_instance:
+            risajuu = self.risajuu_instance[risajuu_id]
+        else:
+            risajuu = AI_risajuu(self.risajuu_config)
+            self.risajuu_instance[risajuu_id] = risajuu
+
         async with asyncio.TaskGroup() as tasks:
-            if message.channel.permissions_for(message.channel.guild.default_role).view_channel:
-                tasks.create_task(self.add_reaction(message))
+            if is_DM or message.channel.permissions_for(message.channel.guild.default_role).view_channel:
+                tasks.create_task(self.add_reaction(risajuu, message))
 
-            if message.channel.name in os.getenv("TARGET_CHANNEL_NAME").split(",") or self.user.mentioned_in(message):
-                tasks.create_task(self.reply_to_message(message))
+            if is_DM or (message.guild.name, message.channel.name) in self.targets or self.user.mentioned_in(message):
+                tasks.create_task(self.reply_to_message(risajuu, message))
 
-    async def add_reaction(self, message):
+    async def add_reaction(self, risajuu, message):
         p = float(os.getenv("REACTION_PROBABILITY"))
         if random.random() < p:
-            reaction = await self.risajuu.react(message.content)
+            reaction = await risajuu.react(message.content)
             if reaction is not None:
                 try:
                     await message.add_reaction(reaction)
                 except TypeError:
                     pass
 
-    async def reply_to_message(self, message):
+    async def reply_to_message(self, risajuu, message):
         input_text = message.content
 
         if input_text.startswith("カスタム\n"):
             custom_instruction = input_text.replace("カスタム\n", "")
-            self.risajuu.current_system_instruction = custom_instruction
+            risajuu.set_custom_instruction(custom_instruction)
             text = "カスタム履歴を追加して新たなチャットで開始したじゅう！いつものりさじゅうに戻ってほしくなったら、「リセット」って言うじゅう！"
             await message.channel.send(text)
             return
@@ -58,7 +92,7 @@ class Risajuu_discord_client(discord.Client):
             if len(message.attachments) == 1 and message.attachments[0].filename.endswith(".json"):
                 json_data = await message.attachments[0].read()
                 json_str = json_data.decode("utf-8").replace("\n", "")
-                self.risajuu.import_history(json_str)
+                risajuu.import_history(json_str)
                 text = "履歴をインポートしたじゅう！"
             else:
                 text = "インポートするには、1つのJSONファイルを添付してほしいじゅう！"
@@ -66,7 +100,7 @@ class Risajuu_discord_client(discord.Client):
             return
 
         if input_text.endswith("エクスポート"):
-            json_str = self.risajuu.export_history()
+            json_str = risajuu.export_history()
             timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
             prefix = f"risajuu_history_{timestamp}_"
             with tempfile.NamedTemporaryFile(
@@ -79,7 +113,7 @@ class Risajuu_discord_client(discord.Client):
             await message.channel.send(text)
             return
 
-        async for reply in self.risajuu.reply(message.content, message.attachments):
+        async for reply in risajuu.reply(message.content, message.attachments):
             async with message.channel.typing():
                 body = reply.body
                 match reply.type:

--- a/discord_client.py
+++ b/discord_client.py
@@ -9,6 +9,10 @@ import discord
 from ai_risajuu import ReplyType
 
 
+def split_message_text(text, chunk_size=1500):
+    return [text[i : i + chunk_size] for i in range(0, len(text), chunk_size)]
+
+
 class Risajuu_discord_client(discord.Client):
     def __init__(self, risajuu):
         intents = discord.Intents.default()
@@ -80,7 +84,8 @@ class Risajuu_discord_client(discord.Client):
                 body = reply.body
                 match reply.type:
                     case ReplyType.text:
-                        await message.channel.send(body)
+                        for chunk in split_message_text(body):
+                            await message.channel.send(chunk)
                     case ReplyType.file:
                         await message.channel.send(file=discord.File(body, filename=os.path.basename(body)))
                         os.remove(body)

--- a/keep_alive.py
+++ b/keep_alive.py
@@ -1,15 +1,20 @@
-from flask import Flask
 from threading import Thread
 
-app = Flask('')
+from flask import Flask
 
-@app.route('/')
+app = Flask("")
+
+
+@app.route("/")
 def home():
     return "I'm alive"
 
+
 def run():
-    app.run(host='0.0.0.0', port=8080)
+    app.run(host="0.0.0.0", port=8080)
+
 
 def keep_alive():
     t = Thread(target=run)
+    t.daemon = True
     t.start()

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import os
 
 from dotenv import load_dotenv
 
-from ai_risajuu import AI_risajuu
+from ai_risajuu import RisajuuConfig
 from discord_client import Risajuu_discord_client
 from keep_alive import keep_alive
 
@@ -15,15 +15,20 @@ def main():
     with open("common_prompt.md", "r", encoding="utf-8") as f:
         common_prompt = f.read()
 
-    google_api_key = os.getenv("GOOGLE_API_KEY")
-    risajuu = AI_risajuu(google_api_key, common_prompt, system_prompt)
+    risajuu_config = RisajuuConfig(
+        google_api_key=os.getenv("GOOGLE_API_KEY"),
+        main_model_name=os.getenv("MAIN_MODEL_NAME"),
+        sub_model_name=os.getenv("SUB_MODEL_NAME"),
+        system_instruction=system_prompt,
+        common_instruction=common_prompt,
+    )
 
-    discord_token = os.getenv("DISCORD_TOKEN")
-    client = Risajuu_discord_client(risajuu)
+    client = Risajuu_discord_client(risajuu_config)
 
     # Webサーバの立ち上げ
     keep_alive()
 
+    discord_token = os.getenv("DISCORD_TOKEN")
     client.run(discord_token)
 
 

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ def main():
     # Discordクライアントの起動
     discord_token = os.getenv("DISCORD_TOKEN")
     client.run(discord_token)
+    print("\n=== exit ===")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -8,13 +8,17 @@ from keep_alive import keep_alive
 
 
 def main():
+    # .envファイルの内容を環境変数として取り込む
     load_dotenv()
 
+    # システムプロンプトの読み込み
+    # 「カスタム」してもcommon_promptは残る
     with open("default_prompt.md", "r", encoding="utf-8") as f:
         system_prompt = f.read()
     with open("common_prompt.md", "r", encoding="utf-8") as f:
         common_prompt = f.read()
 
+    # AIりさじゅうの基本設定
     risajuu_config = RisajuuConfig(
         google_api_key=os.getenv("GOOGLE_API_KEY"),
         main_model_name=os.getenv("MAIN_MODEL_NAME"),
@@ -23,11 +27,13 @@ def main():
         common_instruction=common_prompt,
     )
 
+    # Discordクライアントの初期化
     client = Risajuu_discord_client(risajuu_config)
 
     # Webサーバの立ち上げ
     keep_alive()
 
+    # Discordクライアントの起動
     discord_token = os.getenv("DISCORD_TOKEN")
     client.run(discord_token)
 

--- a/main.py
+++ b/main.py
@@ -15,14 +15,14 @@ def main():
     with open("common_prompt.md", "r", encoding="utf-8") as f:
         common_prompt = f.read()
 
-    google_api_key = os.environ["GOOGLE_API_KEY"]
+    google_api_key = os.getenv("GOOGLE_API_KEY")
     risajuu = AI_risajuu(google_api_key, common_prompt, system_prompt)
-
-    # Webサーバの立ち上げ
-    keep_alive()
 
     discord_token = os.getenv("DISCORD_TOKEN")
     client = Risajuu_discord_client(risajuu)
+
+    # Webサーバの立ち上げ
+    keep_alive()
 
     client.run(discord_token)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord.py==2.1.1
 Flask==2.3.3
 python-dotenv
-google-genai
+google-genai>=1.19.0
 pydantic


### PR DESCRIPTION
- リアクションの生成を返答メッセージの生成と並行して行うようにした
- split_message_textをdiscord_client.pyに移動して使用するようにした
- AI_risajuuクラスをサーバー・DMごとにインスタンス化するようにした
- ソースコードにコメントを付けた
- 入力中インジケータを可能な限り長く表示できるようにした

今回の変更に伴って**TARGET_CHANNEL_NAMEの指定方法を下のように変更した**ためデプロイ前に注意
`TARGET_CHANNEL_NAME='server_name/channel_name'`